### PR TITLE
Fix Python version in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     # The type of runner that the job will run on.
     runs-on: ubuntu-latest
-    # Configures the build to use Python 3.9.9.
+    # Configures the build to use the latest version of Python 3.
     strategy:
       matrix:
-        python-version: [3.9.9]
+        python-version: [3.x]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can


### PR DESCRIPTION
## Changes
- Fixed Python version used by GitHub Actions by changing it from `3.9.9` to `3.x`.
  - It previously broke, as Python was updated from `3.9.9` to `3.9.10`, which meant GitHub Actions couldn't find the version to use.