### PR TITLE
fix issue with gallons causing overcount of cost

### DIFF
--- a/src/travel_buddy/helpers/helper_routes.py
+++ b/src/travel_buddy/helpers/helper_routes.py
@@ -120,7 +120,7 @@ def calculate_fuel_cost(fuel_used: float, fuel_type: str) -> float:
         The cost of fuel used
     """
     fuel_price = get_fuel_price(fuel_type)
-    total_cost = convert_gallons_to_litres(fuel_used) * fuel_price
+    total_cost = fuel_used * fuel_price
     return total_cost
 
 


### PR DESCRIPTION
## Changes
- Fuel cost was previously calculated incorrectly due to `convert_gallons_to_litres` being called twice in the processing flow.